### PR TITLE
web platform: avoid using over 32bit bitwise ops

### DIFF
--- a/lib/core/md/m68/alu.dart
+++ b/lib/core/md/m68/alu.dart
@@ -7,7 +7,8 @@ extension Alu on M68 {
     final r = a + b + (useXf && xf ? 1 : 0);
     // debug("add r: ${r.hex32} a: ${a.hex32} b: ${b.hex32} xf: $xf");
 
-    xf = cf = r.over(size);
+    final carryBits = (a & b) | ((a | b) & ~r);
+    xf = cf = carryBits.msb(size);
     nf = r.msb(size);
     vf = (~(a ^ b) & (a ^ r)).msb(size); // output changed && input not differed
     zf = (!useXf || zf) && r.mask(size) == 0;
@@ -20,7 +21,8 @@ extension Alu on M68 {
     // debug(
     //     "sub r: ${r.hex32} a: ${a.hex32} b: ${b.hex32} xf: $xf");
 
-    cf = r.over(size);
+    final carryBits = (~a & b) | ((~a | b) & r);
+    cf = carryBits.msb(size);
     if (!cmp) {
       xf = cf;
     }
@@ -111,8 +113,9 @@ extension Alu on M68 {
         vf = (r & affectedBits) != 0 && (r & affectedBits) != affectedBits;
       }
 
-      r <<= rot;
-      xf = cf = r.over(size);
+      r <<= rot - 1;
+      xf = cf = r.msb(size);
+      r <<= 1;
       nf = r.msb(size);
     } else {
       nf = r.msb(size);
@@ -146,8 +149,9 @@ extension Alu on M68 {
   int lsl(int a, int size, int rot) {
     int r = a.mask(size);
     if (rot != 0) {
-      r <<= rot;
-      xf = cf = r.over(size);
+      r <<= rot - 1;
+      xf = cf = r.msb(size);
+      r <<= 1;
     } else {
       cf = false;
     }

--- a/lib/util/int.dart
+++ b/lib/util/int.dart
@@ -34,14 +34,6 @@ extension IntExt on int {
               ? bit31
               : throw ("unreachable");
 
-  bool over(int size) => size == 1
-      ? bit8
-      : size == 2
-          ? bit16
-          : size == 4
-              ? bit32
-              : throw ("unreachable");
-
   int scale(int size) => size == 1
       ? this
       : size == 2
@@ -123,7 +115,6 @@ extension IntExt on int {
   bool get bit29 => this & 0x20000000 != 0;
   bool get bit30 => this & 0x40000000 != 0;
   bool get bit31 => this & 0x80000000 != 0;
-  bool get bit32 => this & 0x100000000 != 0;
 }
 
 extension IntClip on int {


### PR DESCRIPTION
- bitwise operation to int is limited in 32-bit width on web platform (javascript)
- "over" method in IntExt uses bit32 to detect overflow, caused wrong execution in web.