### PR TITLE
fix/cpu

### DIFF
--- a/lib/core/ps/cdrom.dart
+++ b/lib/core/ps/cdrom.dart
@@ -43,10 +43,10 @@ class Cdrom {
   bool isPlayCDDA = false;
   bool isSeeking = false;
   bool isReading = false;
-  bool isShellOpen = true;
+  bool isShellOpen = false;
   bool isIdError = false;
   bool isSeekError = false;
-  bool isSpindleMotorOn = false;
+  bool isSpindleMotorOn = true;
   bool isError = false;
 
   static const sectorBufferSize = 2352; // 0x930 bytes
@@ -117,6 +117,14 @@ class Cdrom {
     currentIntNo = 0;
 
     isReading = false;
+    isSeeking = false;
+    isPlayCDDA = false;
+    isShellOpen = false;
+    isIdError = false;
+    isSeekError = false;
+    isSpindleMotorOn = true;
+    isError = false;
+
     readingSector = 0;
     seekSector = 0;
     sectorBufferIndex = 0;
@@ -255,6 +263,7 @@ class Cdrom {
       if (result.delay <= 0 && currentIntNo == 0) {
         isCmdBusy = false;
         currentIntNo = result.intNo;
+        resultFifo.clear();
         resultFifo.addAll(result.fifo);
         cmdResults.removeFirst();
 
@@ -360,8 +369,8 @@ class Cdrom {
         irq(2, [status()]);
 
       case 0x09: // Pause
-        isReading = false;
         irq(3, [status()]);
+        isReading = false;
         irq(2, [status()]);
 
       case 0x0a: // Init
@@ -505,7 +514,8 @@ class Cdrom {
 
   String dump() => "status:${status().hex8} bank:$bank "
       "params:[${paramFifo.map((e) => e.hex8).join(" ")}] "
-      "results:${cmdResults.map((r) => "[${r.intNo} ${r.delay} [${r.fifo.map((e) => e.hex8).join(" ")}]]")} "
+      "results:${cmdResults.map((r) => "[${r.intNo} ${r.delay} [${r.fifo.map((e) => e.hex8).join(" ")}]]").join(" ")} "
+      "fifo:[${resultFifo.map((e) => e.hex8).join(" ")}] "
       "${isXaAdpcmBusy ? "Adpcm" : "DRQ"} ${sectorBufferEmpty ? "empty" : "ready"} ${isHighSpeed ? "x2" : "x1"} ${isSectorSize924 ? "924" : "800"} "
       "mask:${intMask.hex8} sector:${dumpSector(readingSector)}";
 

--- a/lib/core/ps/ps_test.dart
+++ b/lib/core/ps/ps_test.dart
@@ -8,7 +8,7 @@ import '../../disc/loader.dart';
 import '../sram.dart';
 import 'ps.dart';
 
-int runSeconds = 10; // run for this many seconds
+int runSeconds = -1; // run for this many seconds
 int runCycles = -1; // run for this many cycles (overrides runSeconds if >= 0)
 int traceAddress = -1; // start logging from this address
 int traceCycleStart = -1; // start logging from this cycle

--- a/lib/core/ps/r3000/cop0.dart
+++ b/lib/core/ps/r3000/cop0.dart
@@ -23,7 +23,7 @@ extension Cop0 on R3000 {
         // debugLog("sr <- ${value.hex32}");
         sr = value;
       case 13:
-        cause = cause.masked(0x30, value);
+        cause = cause.masked(0x300, value);
       case 14:
         epc = value;
     }

--- a/lib/core/ps/r3000/cop0.dart
+++ b/lib/core/ps/r3000/cop0.dart
@@ -33,7 +33,7 @@ extension Cop0 on R3000 {
     switch (inst32 & 0x3f) {
       case 0x10: // rfe
         sr = sr.masked(0x0f, sr >> 2);
-        sr &= ~0x30;
+      // sr &= ~0x30;
       // debugLog(
       //     "cpu: rfe sr:${sr.hex32} cause:${cause.hex32} epc:${epc.hex32}");
       default:

--- a/lib/core/ps/r3000/r3000.dart
+++ b/lib/core/ps/r3000/r3000.dart
@@ -143,7 +143,8 @@ class R3000 {
     immediateReg = 0;
     immediateVal = 0;
 
-    if ((cause & sr & 0xff00 != 0) && sr.bit0) {
+    if ((cause & sr & 0xff00 != 0) && sr.bit0 && read32(instPc).shr26 != 0x12) {
+      // delay excaption if the current instruction is cop2
       exception(Exception.interrupt);
     } else {
       // try {

--- a/lib/core/ps/r3000/r3000.dart
+++ b/lib/core/ps/r3000/r3000.dart
@@ -55,6 +55,7 @@ class R3000 {
   int nextDelayReg = 0, nextDelayVal = 0;
   int delayReg = 0, delayVal = 0;
   int immediateReg = 0, immediateVal = 0;
+  bool inBranchTaken = false;
   bool inBranchDelay = false;
 
   // bios putchar() hacking
@@ -72,6 +73,7 @@ class R3000 {
     immediateReg = 0;
     immediateVal = 0;
 
+    inBranchTaken = false;
     inBranchDelay = false;
 
     r.fillRange(0, 32, 0);
@@ -145,6 +147,7 @@ class R3000 {
       exception(Exception.interrupt);
     } else {
       // try {
+      inBranchTaken = false;
       inBranchDelay = false;
       exec(read32(instPc));
       // } catch (e) {
@@ -187,13 +190,14 @@ class R3000 {
   }
 
   void jump(int addr) {
+    inBranchTaken = true;
     inBranchDelay = true;
     nextPc = addr.mask32;
   }
 
   void exception(int excode, {int? badvaddr}) {
-    sr = sr.masked(0x3f, sr << 2) |
-        0x02; // save old mode, ie bit0-1, and set new mode to kernel (0x02)
+    sr = sr.masked(0x3f,
+        sr << 2); // save old mode, ie bit0-1, and set new mode to kernel (0x00)
 
     cause &= 0xff00; // clear, keep bit8-15 (IM)
     cause |= excode << 2;
@@ -204,7 +208,7 @@ class R3000 {
 
     if (inBranchDelay) {
       epc = instPc.dec4.mask32;
-      cause |= 0xc0000000;
+      cause |= 0x80000000.setBit(30, inBranchTaken);
       tar = pc;
     } else {
       epc = instPc;
@@ -215,6 +219,13 @@ class R3000 {
 
     // debugLog(
     //     "cpu: exception  excode:${excode.hex8} sr:${sr.hex32} cause:${cause.hex32} epc:${epc.hex32}");
+  }
+
+  void branch(bool cond, int rel16) {
+    inBranchDelay = true;
+    if (cond) {
+      jump(pc + (rel16 << 2));
+    }
   }
 
   /// Main instruction dispatch.
@@ -263,17 +274,17 @@ class R3000 {
           0x10 => jal(r[rs].rel32 < 0, 31, pc + (rel16 << 2)), // bltzal
           0x11 => jal(r[rs].rel32 >= 0, 31, pc + (rel16 << 2)), // bgezal
           _ => switch (rt & 1) {
-              0x00 => r[rs].rel32 < 0 ? jump(pc + (rel16 << 2)) : 0, // bltz
-              0x01 => r[rs].rel32 >= 0 ? jump(pc + (rel16 << 2)) : 0, // bgez
+              0x00 => branch(r[rs].rel32 < 0, rel16), // bltz
+              0x01 => branch(r[rs].rel32 >= 0, rel16), // bgez
               _ => _unknown(inst32),
             }
         },
       0x02 => jump(pc & 0xf0000000 | inst32.mask26 << 2),
       0x03 => jal(true, 31, pc & 0xf0000000 | inst32.mask26 << 2), // jal
-      0x04 => r[rs] == r[rt] ? jump(pc + (rel16 << 2)) : 0, // beq
-      0x05 => r[rs] != r[rt] ? jump(pc + (rel16 << 2)) : 0, // bne
-      0x06 => r[rs].rel32 <= 0 ? jump(pc + (rel16 << 2)) : 0, // blez
-      0x07 => r[rs].rel32 > 0 ? jump(pc + (rel16 << 2)) : 0, // bgtz
+      0x04 => branch(r[rs] == r[rt], rel16), // beq
+      0x05 => branch(r[rs] != r[rt], rel16), // bne
+      0x06 => branch(r[rs].rel32 <= 0, rel16), // blez
+      0x07 => branch(r[rs].rel32 > 0, rel16), // bgtz
       0x08 => add(rt, r[rs], rel16),
       0x09 => immediate(rt, r[rs] + rel16.mask32), // addiu
       0x0a => immediate(rt, r[rs].rel32 < rel16 ? 1 : 0), // slti

--- a/lib/core/ps/spu/adpcm.dart
+++ b/lib/core/ps/spu/adpcm.dart
@@ -8,16 +8,17 @@ extension VoiceAdpcmDecoder on Voice {
           "SPU${no.decimal2z}: addr:${_addr.hex24} ram:${spu.ram.sublist(_addr, _addr + 16).map((e) => e.hex8).join(" ")}");
     }
 
-    final loop = spu.ram[_addr.inc];
+    final header = spu.readRam16(_addr);
+    final loop = header >> 8;
 
     if (loop.bit2) {
       repeatAddr = _addr;
     }
 
-    int shift = spu.ram[_addr] & 0x0f;
+    int shift = header & 0x0f;
     shift = (shift > 12) ? 9 : shift;
 
-    final filter = spu.ram[_addr] >> 4 & 0x07;
+    final filter = header >> 4 & 0x07;
 
     final (c1, c2) =
         [(0, 0), (60, 0), (115, -52), (98, -55), (122, -60)][filter.min(4)];

--- a/lib/core/ps/spu/spu.dart
+++ b/lib/core/ps/spu/spu.dart
@@ -156,7 +156,7 @@ class Spu {
     if (irqEnabled && addr == _irqAddr) {
       _status = _status.setBit(6, true); // set irq flag
       bus.setIrq(9);
-      debugLog("spu: IRQ triggered at ${_fifoAddr.hex24}");
+      // debugLog("spu: IRQ triggered at ${_fifoAddr.hex24}");
     }
 
     return ram.getUint16LE(addr);


### PR DESCRIPTION
- **ps: gpu: reflect odd frame bit in GPUSTAT**
- **ps: gpu: fix modulate's wrong r and b handling**
- **ps: timer: remove cache for mode bits**
- **ps: gpu: use display height**
- **ps: fix small stuffs**
- **ps: decompose bus access into 8bit**
- **ps: decompose write32**
- **ps: timer: fix behavior when target = 0**
- **ps: more read/write decompose refactoring**
- **ps: dma: fix byte write handling**
- **ps: gpu: pseudo rounding than cut**
- **ps: cdrom: add seekSector**
- **ps: cdrom: GetLocL returns infos from rawSector**
- **ps: cdrom: Init clears mode reg**
- **ps: spu: some fixes**
- **ps: timer: fix initial pause state**
- **ps: dma: small fixes**
- **ps: cpu: fix wrong cause set**
- **ps: cpu: separate branchTaken from branchDelay**
- **ps: cpu: rfe keeps old ie/ku**
- **ps: cpu: delay exception at cop2 inst**
- **ps: cdrom: small fix for status handling**
- **ps: test runner -n option defaults -1 (inf)**
- **ps: spu: invoke irq in decodeBlock**
